### PR TITLE
.input2 was labeled input1 in pretty

### DIFF
--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -14,7 +14,7 @@ extension Stream {
         case .input1:
             return Text("input1").foregroundColor(.red)
         case .input2:
-            return Text("input1").foregroundColor(.green)
+            return Text("input2").foregroundColor(.green)
         case .merge(let l, let r):
             return Text("merge(\(l.pretty), \(r.pretty))")
         case .chain(let l, let r):


### PR DESCRIPTION
Hi,

Just finished watching [Swift Talk # 307](https://talk.objc.io/episodes/S01E307-visualizing-async-algorithms-ui-for-combining-algorithms) and it seems a copy paste error happened so `.input2` ends up outputting `input1` in the pretty property like shown below:

```swift
extension Stream {
    var pretty: Text {
        switch self {
        case .input1:
            return Text("input1").foregroundColor(.red)
        case .input2:
            return Text("input1").foregroundColor(.green)
        case .merge(let l, let r):
            return Text("merge(\(l.pretty), \(r.pretty))")
        case .chain(let l, let r):
            return Text("chain(\(l.pretty), \(r.pretty))")
        case .zip(let l, let r):
            return Text("zip(\(l.pretty), \(r.pretty))")
        case .combineLatest(let l, let r):
            return Text("combineLatest(\(l.pretty), \(r.pretty))")
        case .adjacentPairs(let stream):
            return Text("\(stream.pretty).adjacentPairs()") 
        }
    }
}
```

Enjoying the series so far, so keep it coming :)

-Morten